### PR TITLE
minor: adding typos

### DIFF
--- a/home/modules/shell.nix
+++ b/home/modules/shell.nix
@@ -29,6 +29,7 @@ in
     [
       awscli2
       tree
+      typos
       jq
       curl
       wget


### PR DESCRIPTION
`typos` is cli spelling checker (written in Rust btw).