### PR TITLE
feat(netcup): add canola.nvim runner + enable Docker

### DIFF
--- a/hosts/netcup/configuration.nix
+++ b/hosts/netcup/configuration.nix
@@ -40,6 +40,10 @@ let
       class = "general";
     }
     {
+      repo = "canola.nvim";
+      class = "general";
+    }
+    {
       repo = "canola-collection";
       class = "general";
     }
@@ -310,10 +314,13 @@ in
     shell = "${pkgs.bash}/bin/bash";
   };
 
+  virtualisation.docker.enable = true;
+
   users.users.github-runner = {
     isSystemUser = true;
     group = "github-runner";
     home = "/var/lib/github-runner";
+    extraGroups = [ "docker" ];
   };
 
   users.groups.git = { };

--- a/hosts/netcup/configuration.nix
+++ b/hosts/netcup/configuration.nix
@@ -145,6 +145,7 @@ let
       ];
       extraPackages = with pkgs; [
         curl
+        diffutils
         fd
         gh
         gnumake
@@ -167,6 +168,7 @@ let
         PIP_CACHE_DIR = "${cacheRoot}/pip";
         PRE_COMMIT_HOME = "${cacheRoot}/pre-commit";
         RUSTUP_HOME = "${cacheRoot}/rustup";
+        TMPDIR = "/var/lib/github-runner/tmp";
         UV_CACHE_DIR = "${cacheRoot}/uv";
         XDG_CACHE_HOME = "${cacheRoot}/xdg-cache";
         XDG_DATA_HOME = "${cacheRoot}/xdg-data";
@@ -340,6 +342,7 @@ in
     "d /etc/github-runner 0750 root root -"
     "d /var/cache/github-runner 0750 github-runner github-runner -"
     "d /var/lib/github-runner 0750 github-runner github-runner -"
+    "d /var/lib/github-runner/tmp 0750 github-runner github-runner -"
     "d /var/lib/github-runner/work 0750 github-runner github-runner -"
     "d /var/lib/github-runner/work/general 0750 github-runner github-runner -"
     "d /var/lib/github-runner/work/heavy 0750 github-runner github-runner -"

--- a/hosts/netcup/configuration.nix
+++ b/hosts/netcup/configuration.nix
@@ -200,6 +200,16 @@ in
   hardware.enableRedistributableFirmware = false;
   fonts.fontconfig.enable = false;
 
+  programs.nix-ld = {
+    enable = true;
+    libraries = with pkgs; [
+      icu
+      openssl
+      stdenv.cc.cc
+      zlib
+    ];
+  };
+
   networking = {
     hostName = "netcup";
     useDHCP = false;


### PR DESCRIPTION
## Summary
- Add `canola.nvim` to the self-hosted GitHub Actions runner list
- Enable Docker on netcup so `container:`-based workflow jobs (e.g. sioyek-dev AUR publish) can run on self-hosted runners
- Grant the `github-runner` user Docker access via `extraGroups`

#### Test plan
- [ ] `nixos-rebuild` succeeds on netcup
- [ ] canola.nvim runner registers with GitHub
- [ ] sioyek-dev AUR workflow runs successfully with Docker container