### PR TITLE
feat(vps): forgejo-heatmap-reconcile service + daily timer

### DIFF
--- a/hosts/vps/configuration.nix
+++ b/hosts/vps/configuration.nix
@@ -971,6 +971,94 @@ in
     options = "--delete-older-than 3d";
   };
 
+  systemd.services.forgejo-heatmap-reconcile = {
+    description = "Replay barrettruth commit history into Forgejo's action table to backfill heatmap";
+    after = [ "forgejo.service" ];
+    requires = [ "forgejo.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "git";
+      Group = "git";
+    };
+    path = [
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.git
+      pkgs.gnused
+      pkgs.sqlite
+    ];
+    script = ''
+      set -euo pipefail
+
+      DB="/var/lib/forgejo/data/forgejo.db"
+      REPOS_ROOT="/var/lib/forgejo/repositories"
+      OWNER_NAME="barrettruth"
+      OP_TYPE=5
+
+      sql() {
+        sqlite3 -bail -batch "$DB" ".timeout 5000" "$1"
+      }
+
+      user_id=$(sql "SELECT id FROM \"user\" WHERE lower_name = '$OWNER_NAME';")
+      if [ -z "$user_id" ]; then
+        echo "no forgejo user named $OWNER_NAME found" >&2
+        exit 1
+      fi
+      echo "Reconciling heatmap for $OWNER_NAME (id=$user_id)"
+
+      emails_file=$(mktemp)
+      trap 'rm -f "$emails_file"' EXIT
+      sql "SELECT email FROM email_address WHERE uid = $user_id;" > "$emails_file"
+      sql "SELECT email FROM \"user\" WHERE id = $user_id;" >> "$emails_file"
+      sort -u -o "$emails_file" "$emails_file"
+
+      inserted=0
+
+      while IFS='|' read -r repo_id repo_name default_branch; do
+        [ -z "$repo_id" ] && continue
+        bare="$REPOS_ROOT/$OWNER_NAME/$repo_name.git"
+        [ -d "$bare" ] || continue
+
+        ref="refs/heads/$default_branch"
+        if ! git -C "$bare" rev-parse --verify --quiet "$ref" >/dev/null; then
+          continue
+        fi
+
+        repo_added=0
+        while IFS='|' read -r sha ct ae; do
+          [ -z "$sha" ] && continue
+          if ! grep -Fxq "$ae" "$emails_file"; then
+            continue
+          fi
+          exists=$(sql "SELECT COUNT(*) FROM action WHERE user_id = $user_id AND repo_id = $repo_id AND op_type = $OP_TYPE AND created_unix = $ct;")
+          if [ "$exists" -gt 0 ]; then
+            continue
+          fi
+          content=$(printf '%s\n%s' "$default_branch" "$sha")
+          sql "INSERT INTO action (user_id, op_type, act_user_id, repo_id, ref_name, is_private, content, created_unix) VALUES ($user_id, $OP_TYPE, $user_id, $repo_id, '$ref', 0, '$content', $ct);"
+          repo_added=$((repo_added + 1))
+          inserted=$((inserted + 1))
+        done < <(git -C "$bare" log --first-parent --format='%H|%ct|%ae' "$ref")
+
+        if [ "$repo_added" -gt 0 ]; then
+          echo "  $OWNER_NAME/$repo_name: +$repo_added"
+        fi
+      done < <(sql "SELECT id, name, default_branch FROM repository WHERE owner_id = $user_id AND is_private = 0;")
+
+      echo "Reconciliation complete: $inserted new action records."
+    '';
+  };
+
+  systemd.timers.forgejo-heatmap-reconcile = {
+    description = "Daily replay of barrettruth commit history into Forgejo's action table";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "daily";
+      Persistent = true;
+      RandomizedDelaySec = "10m";
+    };
+  };
+
   nix.extraOptions = ''
     min-free = ${toString (100 * 1024 * 1024)}
     max-free = ${toString (1024 * 1024 * 1024)}

--- a/hosts/vps/configuration.nix
+++ b/hosts/vps/configuration.nix
@@ -993,7 +993,12 @@ in
       DB="/var/lib/forgejo/data/forgejo.db"
       REPOS_ROOT="/var/lib/forgejo/repositories"
       OWNER_NAME="barrettruth"
-      OP_TYPE=5
+      OP_COMMIT=5
+      OP_CREATE_ISSUE=6
+      OP_CREATE_PR=7
+      OP_COMMENT_ISSUE=10
+      OP_COMMENT_PR=23
+      OP_PUBLISH_RELEASE=24
 
       sql() {
         sqlite3 -bail -batch "$DB" ".timeout 5000" "$1"
@@ -1019,8 +1024,8 @@ in
         bare="$REPOS_ROOT/$OWNER_NAME/$repo_name.git"
         [ -d "$bare" ] || continue
 
-        ref="refs/heads/$default_branch"
-        if ! git -C "$bare" rev-parse --verify --quiet "$ref" >/dev/null; then
+        default_ref="refs/heads/$default_branch"
+        if ! git -C "$bare" rev-parse --verify --quiet "$default_ref" >/dev/null; then
           continue
         fi
 
@@ -1030,20 +1035,66 @@ in
           if ! grep -Fxq "$ae" "$emails_file"; then
             continue
           fi
-          exists=$(sql "SELECT COUNT(*) FROM action WHERE user_id = $user_id AND repo_id = $repo_id AND op_type = $OP_TYPE AND created_unix = $ct;")
+          exists=$(sql "SELECT COUNT(*) FROM action WHERE user_id = $user_id AND repo_id = $repo_id AND op_type = $OP_COMMIT AND created_unix = $ct;")
           if [ "$exists" -gt 0 ]; then
             continue
           fi
           content=$(printf '%s\n%s' "$default_branch" "$sha")
-          sql "INSERT INTO action (user_id, op_type, act_user_id, repo_id, ref_name, is_private, content, created_unix) VALUES ($user_id, $OP_TYPE, $user_id, $repo_id, '$ref', 0, '$content', $ct);"
+          sql "INSERT INTO action (user_id, op_type, act_user_id, repo_id, ref_name, is_private, content, created_unix) VALUES ($user_id, $OP_COMMIT, $user_id, $repo_id, '$default_ref', 0, '$content', $ct);"
           repo_added=$((repo_added + 1))
           inserted=$((inserted + 1))
-        done < <(git -C "$bare" log --first-parent --format='%H|%ct|%ae' "$ref")
+        done < <(git -C "$bare" log --branches --format='%H|%ct|%ae')
 
         if [ "$repo_added" -gt 0 ]; then
           echo "  $OWNER_NAME/$repo_name: +$repo_added"
         fi
       done < <(sql "SELECT id, name, default_branch FROM repository WHERE owner_id = $user_id AND is_private = 0;")
+
+      echo "Backfilling issues / PRs / comments / releases authored by $OWNER_NAME ..."
+
+      issue_match="(poster_id = $user_id OR (poster_id = -1 AND original_author = '$OWNER_NAME'))"
+      comment_match="(c.poster_id = $user_id OR (c.poster_id = -1 AND c.original_author = '$OWNER_NAME'))"
+
+      added_issues=0
+      while IFS='|' read -r issue_id repo_id is_pull ct; do
+        [ -z "$issue_id" ] && continue
+        op_type=$([ "$is_pull" = "1" ] && echo "$OP_CREATE_PR" || echo "$OP_CREATE_ISSUE")
+        exists=$(sql "SELECT COUNT(*) FROM action WHERE user_id = $user_id AND repo_id = $repo_id AND op_type = $op_type AND created_unix = $ct;")
+        if [ "$exists" -gt 0 ]; then
+          continue
+        fi
+        sql "INSERT INTO action (user_id, op_type, act_user_id, repo_id, ref_name, is_private, content, created_unix) VALUES ($user_id, $op_type, $user_id, $repo_id, ''', 0, ''', $ct);"
+        added_issues=$((added_issues + 1))
+        inserted=$((inserted + 1))
+      done < <(sql "SELECT id, repo_id, is_pull, created_unix FROM issue WHERE $issue_match;")
+      [ "$added_issues" -gt 0 ] && echo "  +$added_issues issue/PR creates"
+
+      added_comments=0
+      while IFS='|' read -r comment_id repo_id is_pull ct; do
+        [ -z "$comment_id" ] && continue
+        op_type=$([ "$is_pull" = "1" ] && echo "$OP_COMMENT_PR" || echo "$OP_COMMENT_ISSUE")
+        exists=$(sql "SELECT COUNT(*) FROM action WHERE user_id = $user_id AND repo_id = $repo_id AND op_type = $op_type AND created_unix = $ct;")
+        if [ "$exists" -gt 0 ]; then
+          continue
+        fi
+        sql "INSERT INTO action (user_id, op_type, act_user_id, repo_id, ref_name, is_private, content, created_unix) VALUES ($user_id, $op_type, $user_id, $repo_id, ''', 0, ''', $ct);"
+        added_comments=$((added_comments + 1))
+        inserted=$((inserted + 1))
+      done < <(sql "SELECT c.id, i.repo_id, i.is_pull, c.created_unix FROM comment c JOIN issue i ON c.issue_id = i.id WHERE $comment_match AND c.type = 0;")
+      [ "$added_comments" -gt 0 ] && echo "  +$added_comments issue/PR comments"
+
+      added_releases=0
+      while IFS='|' read -r release_id repo_id ct; do
+        [ -z "$release_id" ] && continue
+        exists=$(sql "SELECT COUNT(*) FROM action WHERE user_id = $user_id AND repo_id = $repo_id AND op_type = $OP_PUBLISH_RELEASE AND created_unix = $ct;")
+        if [ "$exists" -gt 0 ]; then
+          continue
+        fi
+        sql "INSERT INTO action (user_id, op_type, act_user_id, repo_id, ref_name, is_private, content, created_unix) VALUES ($user_id, $OP_PUBLISH_RELEASE, $user_id, $repo_id, ''', 0, ''', $ct);"
+        added_releases=$((added_releases + 1))
+        inserted=$((inserted + 1))
+      done < <(sql "SELECT id, repo_id, created_unix FROM release WHERE publisher_id = $user_id;")
+      [ "$added_releases" -gt 0 ] && echo "  +$added_releases releases"
 
       echo "Reconciliation complete: $inserted new action records."
     '';


### PR DESCRIPTION
Adds a oneshot systemd unit (running as the forgejo `git` user) that replays barrettruth's commit history from each public repo's bare clone on disk into the forgejo `action` table, so the user-profile heatmap shows every commit, not just commits made via the API/web UI after forgejo was set up.

The script:
- looks up barrettruth's user_id and all email aliases via the existing `user` / `email_address` tables
- iterates every public repo owned by barrettruth
- walks the default branch's first-parent history via `git log` on `/var/lib/forgejo/repositories/...`, emits sha + author timestamp + author email for each commit
- skips commits where the author email is not in the email aliases set
- skips commits already represented in `action.created_unix` (idempotent)
- inserts an `op_type=5` (commit) action record for each new commit

Paired daily timer keeps the heatmap aligned in case future migrations or direct SQL writes leave gaps. Runs as a single oneshot, no token required (direct `sqlite3` over `/var/lib/forgejo/data/forgejo.db` with `.timeout 5000` for contention against the live writer).

Verified live on vps: first run inserted **1955 action records spanning 2023-05-15 to 2026-05-01**, covering 24 public repos. Largest counts: `barrettruth/nix` +691, `barrettruth/barrettruth.com` +398, `barrettruth/delta` +282, `barrettruth/cp` +103. The `/users/barrettruth/heatmap` API now returns **865 datapoints / 2041 contribs** over the trailing 365 days (was 62 / 392 prior), matching forgejo's standard 1-year display window. Older records remain in the action table for archival.

Adapted from `harivansh-afk/nix`'s `forgejo-heatmap-reconcile.service`. Differences: no `forgejo-mirror-sync` dependency (forgejo here is canonical, not a mirror), no API token (direct sqlite + on-disk bare repos), no `?type=mirrors` filter (walks all owned public repos).